### PR TITLE
Update blog post titles for SEO discoverability

### DIFF
--- a/_posts/2020-09-20-critical-review-of-power-hungry-USA-energy-future.md
+++ b/_posts/2020-09-20-critical-review-of-power-hungry-USA-energy-future.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "The Energy Dilemma I (Pre-COVID-19): Why N2N Isn't the Magic Bullet for America's Energy Future"
+title: "Why Natural Gas to Nuclear (N2N) Can't Solve America's Energy Problem: A Critical Review"
 excerpt:  | 
     A pre-COVID-19 critical review of Robert Bryce's "<u>Power Hungry: The Myths of 'Green' Energy and the Real Fuels of the Future.</u>"
 date: 2020-09-20

--- a/_posts/2024-07-15-karpathy-nn-zero-to-hero.md
+++ b/_posts/2024-07-15-karpathy-nn-zero-to-hero.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Implementation of Karpathy's Neural Networks: Zero to Hero Lecture Series"
+title: "Karpathy's Neural Networks Zero to Hero: Complete Implementation Notes"
 excerpt:  |
     This blog post presents my detailed implementation of Andrej Karpathy's Neural Networks: Zero to Hero YouTube lecture series and exercises in Jupyter Notebook. The articles go deeply from NNs to MLPs to CNNs to LLMs to ensure a thorough and robust understanding of neural networks.
 date: 2024-07-15

--- a/_posts/2024-08-02-char-level-LM-RNN.md
+++ b/_posts/2024-08-02-char-level-LM-RNN.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Implementing a Recurrent Neural Network (RNN) From Scratch in Python: Character-Level Language Model Case Study"
+title: "Building an RNN from Scratch in Python: Character-Level Language Model with BPTT"
 excerpt: In this blog post, we'll dive deep into the implementation of a character-level language model using a vanilla Recurrent Neural Network (RNN). This type of model can learn to generate text one character at a time, capturing the patterns and structure of the language it's trained on. We'll walk through the code, explain the key concepts, and provide insights into how this model works.
 date: 2024-08-02
 mathjax: true

--- a/_posts/2025-02-24-critical-review-of-power-hungry-USA-2.md
+++ b/_posts/2025-02-24-critical-review-of-power-hungry-USA-2.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "The Energy Dilemma II (Post-COVID-19): Why N2N Isn't the Magic Bullet for America's Energy Future"
+title: "America's Energy Strategy After COVID-19: Natural Gas, Nuclear, and Renewables Reassessed"
 excerpt:  | 
     A post-COVID-19 critical review of Robert Bryce's "<u>Power Hungry: The Myths of 'Green' Energy and the Real Fuels of the Future.</u>" 
 date: 2025-02-24

--- a/_posts/2025-05-30-backpropagation.md
+++ b/_posts/2025-05-30-backpropagation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Understanding Backpropagation in Deep Learning"
+title: "Backpropagation from Scratch: Chain Rule, Math, and Python Code"
 excerpt: A highly technical yet understandable exploration of backpropagation, detailing its mechanics, mathematical foundations, and practical applications, making it accessible to those with a basic understanding of calculus and machine learning.
 date: 2025-05-30
 mathjax: true

--- a/_posts/2025-05-30-machine-learning-key-math-eqns.md
+++ b/_posts/2025-05-30-machine-learning-key-math-eqns.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Essential Machine Learning Equations: A Reference Guide"
+title: "Machine Learning Equations Cheat Sheet: From Entropy to Attention"
 excerpt: A reference guide to fundamental machine learning equations with correct implementations and clear explanations of how they connect to each other.
 date: 2025-05-30
 mathjax: true

--- a/_posts/2026-01-22-neural-net-optimizers.md
+++ b/_posts/2026-01-22-neural-net-optimizers.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "A Complete Guide to Neural Network Optimizers"
+title: "Neural Network Optimizers Compared: SGD, Adam, AdamW, and Muon"
 excerpt: From SGD to Muon, explore how each optimizer builds on its predecessors to solve gradient descent challenges in deep learning.
 date: 2026-01-22
 mathjax: true

--- a/_posts/2026-02-09-mathematical-machine-learning-foundations.md
+++ b/_posts/2026-02-09-mathematical-machine-learning-foundations.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Architectural and Mathematical Foundations of Machine Learning: A Rigorous Synthesis of Theory, Geometry, and Implementation"
+title: "Machine Learning Math: From Linear Algebra to Attention — A Rigorous Deep Dive"
 excerpt: A rigorous exploration of machine learning mathematics, from information theory and linear algebra to optimization dynamics and generative models, with correct implementations and theoretical connections.
 date: 2026-02-09
 mathjax: true

--- a/_posts/2026-02-24-rl-sutton-barto-notes-ch008.md
+++ b/_posts/2026-02-24-rl-sutton-barto-notes-ch008.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Sutton & Barto, Ch. 08: Planning & Learning with Tabular Methods (Personal Notes)"
+title: "Model-Based RL Explained: Dyna-Q, MCTS, and Prioritized Sweeping (S&B Ch. 8)"
 excerpt: Notes on model-based RL, Dyna-Q, prioritized sweeping, trajectory sampling, RTDP, heuristic search, rollout algorithms, and Monte Carlo Tree Search.
 date: 2026-02-24
 mathjax: true

--- a/_posts/2026-02-27-rl-sutton-barto-notes-ch009.md
+++ b/_posts/2026-02-27-rl-sutton-barto-notes-ch009.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Sutton & Barto, Ch. 09: On-Policy Prediction with Approximation (Personal Notes)"
+title: "Value Function Approximation in RL: Tile Coding, Fourier Basis, and SGD (S&B Ch. 9)"
 excerpt: Notes on value-function approximation, the prediction objective (VE), stochastic gradient descent, linear methods, feature construction, ANNs, LSTD, memory-based and kernel-based approximation, and interest & emphasis.
 date: 2026-02-27
 mathjax: true

--- a/_posts/2026-03-01-tonal-fidelity-multilingual-asr.md
+++ b/_posts/2026-03-01-tonal-fidelity-multilingual-asr.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Tonal Fidelity in Multilingual ASR: A Diagnostic Evaluation"
+title: "Evaluating Tone Preservation in ASR: How Meta's omniASR Handles Igbo Diacritics"
 excerpt: Controlled evaluation of omniASR-CTC-1B on Igbo language using 21 systematically designed samples. Diacritic Error Rate (DER) quantifies tone-specific failures. Bootstrap resampling (10,000 iterations) yields 75.5% loss (95% CI [57.1%, 89.7%]). Monotone control reveals orthographic bias. Includes full methodology, code, and reproducibility guide.
 date: 2026-03-01
 mathjax: true

--- a/_posts/2026-03-04-igbo-asr-tonal-eval.md
+++ b/_posts/2026-03-04-igbo-asr-tonal-eval.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "When Your Voice Assistant Can't Hear Tones: Evaluating ASR Bias in Igbo"
+title: "Why AI Voice Assistants Fail Tonal Languages: ASR Bias in Igbo"
 excerpt: A systematic evaluation of tonal fidelity in facebook/omniASR-CTC-1B reveals 75% diacritic loss on Igbo language tone marks. Evidence suggests the model generates tones probabilistically rather than acoustically.
 date: 2026-03-04
 mathjax: true

--- a/_posts/2026-03-09-rl-sutton-barto-notes-ch010.md
+++ b/_posts/2026-03-09-rl-sutton-barto-notes-ch010.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Sutton & Barto, Ch. 10: On-Policy Control with Approximation (Personal Notes)"
+title: "Semi-Gradient Sarsa and the Average Reward Setting in RL (S&B Ch. 10)"
 excerpt: Notes on episodic semi-gradient control, n-step Sarsa, average reward for continuing tasks, deprecating the discounted setting, and differential semi-gradient n-step Sarsa.
 date: 2026-03-09
 mathjax: true

--- a/_posts/2026-03-09-rl-sutton-barto-notes-ch011.md
+++ b/_posts/2026-03-09-rl-sutton-barto-notes-ch011.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Sutton & Barto, Ch. 11: Off-Policy Methods with Approximation (Personal Notes)"
+title: "The Deadly Triad in RL: Off-Policy Learning with Function Approximation (S&B Ch. 11)"
 excerpt: Notes on semi-gradient off-policy methods, examples of divergence, the deadly triad, linear value-function geometry, gradient descent in the Bellman error, learnability, Gradient-TD methods, Emphatic-TD, and reducing variance.
 date: 2026-03-09
 mathjax: true

--- a/_posts/2026-03-13-rl-sutton-barto-notes-ch012.md
+++ b/_posts/2026-03-13-rl-sutton-barto-notes-ch012.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Sutton & Barto, Ch. 12: Eligibility Traces (Personal Notes)"
+title: "Eligibility Traces Explained: TD(λ), Sarsa(λ), and the λ-Return (S&B Ch. 12)"
 excerpt: Notes on the lambda-return and its variants - TD, n-step truncated, online, true online, Sarsa, Watkins's Q, Tree-Backup - dutch traces in MC learning, variable bootstrapping and discounting, off-policy traces with control variates, stable off-policy methods with traces, and implementation issues.
 date: 2026-03-13
 mathjax: true

--- a/_posts/2026-03-16-inkcast.md
+++ b/_posts/2026-03-16-inkcast.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Inkcast: A Free, Browser-Based Audiobook Player"
+title: "Inkcast: Turn Any EPUB or PDF into an Audiobook in Your Browser"
 excerpt: A privacy-first, text-to-speech reader for EPUBs, PDFs, and web articles. Built in a single HTML file, no backend required. 
 date: 2026-03-16
 mathjax: false

--- a/_posts/2026-04-04-muon-muonclip.md
+++ b/_posts/2026-04-04-muon-muonclip.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Muon & MuonClip Optimizers"
+title: "Muon Optimizer Explained: Newton-Schulz Orthogonalization Beyond Adam"
 excerpt: From Muon optimizer to MuonClip covering Adam's limitations, momentum 2D matrix, SVD-based orthogonalization, odd polynomial approximation, Newton-Schulz 5 iteration, the exploding attention logit crisis, and QK-Clip for MHA & MLA.
 date: 2026-04-04
 mathjax: true

--- a/_posts/2026-04-17-sam-2.md
+++ b/_posts/2026-04-17-sam-2.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "SAM 2: Segment Anything in Images & Videos"
+title: "SAM 2 Explained: Meta's Promptable Visual Segmentation Model"
 excerpt: Quick overview on SAM 2, a foundation model for promptable visual segmentation in images and videos, covering the PVS task, model architecture, data engine, SA-V dataset, zero-shot experiments, and conclusions.
 date: 2026-04-17
 mathjax: true

--- a/_posts/2026-04-17-transformers.md
+++ b/_posts/2026-04-17-transformers.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Transformers"
+title: "Transformer Architecture Explained: Self-Attention, Encoders, and Decoders"
 excerpt: Quick overview of the Transformer architecture covering tokenization, attention, multi-head attention, encoders, decoders, masked attention, and cross attention.
 date: 2026-04-17
 mathjax: true

--- a/_posts/2026-05-07-rl-sutton-barto-notes-ch013.md
+++ b/_posts/2026-05-07-rl-sutton-barto-notes-ch013.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 comments: true
-title: "Sutton & Barto, Ch. 13: Policy Gradient Methods (Personal Notes)"
+title: "Policy Gradient Methods: REINFORCE, Actor-Critic, and the Policy Gradient Theorem (S&B Ch. 13)"
 excerpt: Notes on policy approximation and its advantages, the policy gradient theorem and its proof, REINFORCE (Monte Carlo policy gradient), REINFORCE with baseline, actor-critic methods, policy gradient for continuing problems, and policy parametrization for continuous actions.
 date: 2026-05-07
 mathjax: true


### PR DESCRIPTION
Replace generic, internal-notation, and "Personal Notes" titles with keyword-rich titles that match real search queries — no URLs changed.

https://claude.ai/code/session_01TLTQYbaZ86MPLAdoKRuxHw